### PR TITLE
Fix iOS9+ warning.

### DIFF
--- a/LineKit/Line.m
+++ b/LineKit/Line.m
@@ -45,7 +45,13 @@
 }
 
 + (BOOL)shareText:(NSString *)text {
-  return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[NSString stringWithFormat:@"line://msg/text/%@", [text stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]]];
+#ifdef __IPHONE_9_0
+    NSMutableCharacterSet *allowedCharacterSet = [NSMutableCharacterSet alphanumericCharacterSet];
+    [allowedCharacterSet addCharactersInString:@"-._~"];
+    return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[NSString stringWithFormat:@"line://msg/text/%@", [text stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacterSet]]]];
+#else
+    return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[NSString stringWithFormat:@"line://msg/text/%@", [text stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]]]];
+#endif
 }
 
 + (BOOL)shareImage:(UIImage *)image {


### PR DESCRIPTION
Warning by a combination of xcode7.x and iOS9 SDK it came to be issued. Problem has been solved by this PullRequest. Is it possible to get confirmation about the fix?
